### PR TITLE
Update Fedora install requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ As mentioned in the MIT license, you run these commands at your own risk.
 ## Using Ubuntu:
 ```
 $ sudo apt update && sudo apt upgrade
-$ sudo apt install libusb-dev libudev-dev
+$ sudo apt install libusb-dev libudev-dev build-essential
 $ sudo su -
 $ echo 'SUBSYSTEMS=="usb", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="f372" MODE="0666"' > /etc/udev/rules.d/99_luxafor.rules
 $ reboot

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ npm install -g fabufor
 
 ## Using Fedora:
 ```
-$ sudo dnf install systemd-devel
+$ sudo dnf install systemd-devel gcc-c++
 $ sudo su -
 # echo 'SUBSYSTEMS=="usb", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="f372" MODE="0666"' > /etc/udev/rules.d/99_luxafor.rules
 # udevadm control --reload


### PR DESCRIPTION
Fedora also requires the gcc-c++ (g++) package in order to install fabufor.